### PR TITLE
Update Cargo.toml -- Repository URL fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Surrealdb SessionStore for actix-session"
 authors = [
   "ixhbinphoenix <phoenixgames.phoenix13@gmail.com>"
 ]
-repository = "https://github.com/ixhbinphoenix-actix-session-surrealdb"
+repository = "https://github.com/ixhbinphoenix/actix-session-surrealdb"
 categories = ["web-programming::http-server", "web-programming::websocket", "network-programming", "database"]
 keyword = ["web", "actix", "surrealdb", "async", "session"]
 readme = "README.md"


### PR DESCRIPTION
The repository url, which I believe is sourced from this file, leaves the docs.rs and crates.io pages with a broken link to this repository.

See:
https://crates.io/crates/actix-session-surrealdb
and
https://docs.rs/actix-session-surrealdb/0.1.3/actix_session_surrealdb/